### PR TITLE
BC: Update URLs for ITE and Production environments

### DIFF
--- a/docs/en/ssl-certs.md
+++ b/docs/en/ssl-certs.md
@@ -9,14 +9,14 @@ Four certificates must be purchased by the agency - two each for ITE and product
 **Note: This is not required if using CWP infrastructure. In CWP, you should
 [raise a service desk ticket](https://www.cwp.govt.nz/service-desk/new-request/) to begin this process -
 CWP Operations staff will purchase certificates, install them, and invoice you for this service. These
-instructions are only necessary when using this module on infrastructure other than CWP. 
+instructions are only necessary when using this module on infrastructure other than CWP.
 
 ### Requirements when purchasing & installing certificates
 
 RealMe places some restrictions on which certificate authorities can be used, and also the type of
 certificates purchased. Of note, these are:
 
-* SSL Certificates must be purchased from either [RapidSSL](https://www.rapidssl.com/) or 
+* SSL Certificates must be purchased from either [RapidSSL](https://www.rapidssl.com/) or
   [VeriSign](https://www.verisign.com/).
 * When purchasing certificates, RealMe requires that three-year expiries are purchased and used.
 * The certificate bit length must be 2048 (this is generally the default).
@@ -70,3 +70,9 @@ When prompted by `openssl`, use the following parameters:
 | A challenge password     | Leave blank                            |
 | An optional company name | Leave blank                            |
 
+### Manually installing certificates
+
+If not running on CWP, then you must manually create the directory that the `REALME_CERT_DIR` environment variable
+points to. As well as loading the certificates that have been purchased into this folder, the appropriate public keys
+from the RealMe Shared Workspace must be added as well. More information on this process is available within the RealMe
+shared workspace.

--- a/templates/simplesaml-configuration/authsources.php
+++ b/templates/simplesaml-configuration/authsources.php
@@ -86,7 +86,7 @@ if (strlen($proxyHost) > 0 && strlen($proxyPort) > 0) {
 // ITE - RealMe Integrated Test Environment
 $config['realme-ite'] = array(
     'saml:SP',
-    'entityID' => '{{ite-entityID}}', // https://realme-demo.cwp.govt.nz/realme-demo/service1
+    'entityID' => '{{ite-entityID}}',
     'idp' => 'https://www.ite.logon.realme.govt.nz/saml2',
     'discoURL' => null,
 
@@ -107,7 +107,7 @@ $config['realme-ite'] = array(
         'capture_peer_cert' => true,
         'allow_self_signed' => false,
         'verify_depth' => 5,
-        'peer_name' => 'as.ite.logon.realme.govt.nz',
+        'peer_name' => 'ws.ite.realme.govt.nz',
         'cafile' => $_SERVER['DOCUMENT_ROOT']. "/mysite/certificate-bundle.pem"
     )
 );
@@ -156,7 +156,7 @@ $config['realme-prod'] = array(
         'capture_peer_cert' => true,
         'allow_self_signed' => false,
         'verify_depth' => 5,
-        'peer_name' => 'as.logon.realme.govt.nz',
+        'peer_name' => 'ws.realme.govt.nz',
         'cafile' => $_SERVER['DOCUMENT_ROOT']. "/mysite/certificate-bundle.pem"
     )
 );

--- a/templates/simplesaml-configuration/saml20-idp-remote.php
+++ b/templates/simplesaml-configuration/saml20-idp-remote.php
@@ -47,12 +47,12 @@ $metadata['https://www.ite.logon.realme.govt.nz/saml2'] = array(
     'SingleSignOnService.artifact' => 'https://www.ite.logon.realme.govt.nz/sso/logon/metaAlias/logon/logonidp',
 
     'certificate' => 'ite.signing.logon.realme.govt.nz.cer',
-    'saml.SOAPClient.certificate' => 'as.ite.logon.realme.govt.nz.cer',
+    'saml.SOAPClient.certificate' => 'ws.ite.realme.govt.nz.cer',
 
     'ArtifactResolutionService' => array(
         array(
             'index' => 0,
-            'Location' => 'https://as.ite.logon.realme.govt.nz/sso/ArtifactResolver/metaAlias/logon/logonidp',
+            'Location' => 'https://ws.ite.realme.govt.nz/login/sso/ArtifactResolver/metaAlias/logon/logonidp',
             'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:SOAP'
         )
     )
@@ -67,12 +67,12 @@ $metadata['https://www.logon.realme.govt.nz/saml2'] = array(
     'SingleSignOnService.artifact' => 'https://www.logon.realme.govt.nz/sso/logon/metaAlias/logon/logonidp',
 
     'certificate' => 'signing.logon.realme.govt.nz.cer',
-    'saml.SOAPClient.certificate' => 'as.logon.realme.govt.nz.cer',
+    'saml.SOAPClient.certificate' => 'ws.realme.govt.nz.cer',
 
     'ArtifactResolutionService' => array(
         array(
             'index' => 0,
-            'Location' => 'https://as.logon.realme.govt.nz/sso/ArtifactResolver/metaAlias/logon/logonidp',
+            'Location' => 'https://ws.realme.govt.nz/login/sso/ArtifactResolver/metaAlias/logon/logonidp',
             'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:SOAP'
         )
     )


### PR DESCRIPTION
This supports the production RealMe changes currently scheduled for Sunday 01 May.

Note: This should not be used in production until 01 May 2016, as these new hosts and the certificates aren't yet available. If you are using this module outside of CWP, you'll need to gather new certificates from the RealMe Shared Workspace, and you should already have information about what is required for you to do.