### PR TITLE
Add note on re-configuring RealMe module

### DIFF
--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -169,6 +169,35 @@ You should now be able to proceed to testing the standard login form, or [using 
 - Complete an integration to MTS and ITE.
 - Follow the steps as for the ITE environment above, but creating an integration request for production rather than ITE.
 
+## More complex environments
+If you are working with multiple website environments (e.g. multiple test sites or similar), you will encounter issues 
+using the basic configuration system above, because you will want multiple different websites to point to different RealMe 
+integrations (e.g. 'test1' website points to MTS, while 'test2' and 'staging' websites both point to ITE). To do this, 
+each website installation needs a separate RealMe integration (that is, a different SP Entity ID). Once these are 
+configured with RealMe, you can switch them out by modifying configuration. For now (until a solution to #26 is built), 
+the best solution is to use `RealMeService::config()->set()` for SS4, e.g. in your \_config.php:
+
+```php
+use \SilverStripe\RealMe\RealMeService
+
+$entityIds = RealMeService::config()->get('sp_entity_ids');
+$domains = RealMeService::config()->get('metadata_assertion_service_domains');
+
+// Update the configured entity IDs and return domains based on however you know what site you're on
+if (getenv('SITE_ENVIRONMENT') == 'test2')) {
+    $entityIds['ite'] = 'https://test2-domain.example.com/privacy-realm/service-name';
+    $domains['ite'] = 'https://test2-domain.example.com';
+} elseif(getenv('SITE_ENVIRONMENT') == 'staging')) {
+    $entityIds['ite'] = 'https://staging-domain.example.com/privacy-realm/service-name';
+    $domains['ite'] = 'https://staging-domain.example.com';
+}
+
+RealMeService::config()->set('sp_entity_ids', $entityIds);
+RealMeService::config()->set('metadata_assertion_service_domains', $domains);
+```
+
+This will allow you, if necessary, to re-configure the module in real-time based on the website environment. Note that you will still need to deploy the correct private/public keypairs to the correct servers etc.
+
 ## Syncing Realme with SilverStripe members
 After logging in the module can sync the attributes returned from RealMe (depending on your assertion type) and sync the 
 details with the appropriate members.


### PR DESCRIPTION
The module supports re-configuration after initial YML loading for more complex environments - this adds a brief note to the documentation that indicates this and lists what you need to watch out for.