### PR TITLE
Feature/real me login button branding tweak

### DIFF
--- a/src/Authenticator/LoginForm.php
+++ b/src/Authenticator/LoginForm.php
@@ -196,12 +196,14 @@ class LoginForm extends BaseLoginForm
                     self::class . '.ASSERTLOGINBUTTON',
                     'Share your details with {orgname}',
                     ['orgname' => $service->config()->metadata_organisation_display_name]
-                )
+                ),
+                'ShowNewWindowIcon' => false
             ))->renderWith(self::class . '/RealMeLoginButton');
         } else {
             // Login button
             $loginButtonContent = ArrayData::create(array(
-                'Label' => _t(self::class . '.LOGINBUTTON', 'Login')
+                'Label' => _t(self::class . '.LOGINBUTTON', 'Login'),
+                'ShowNewWindowIcon' => true
             ))->renderWith(self::class . '/RealMeLoginButton');
         }
 

--- a/templates/SilverStripe/RealMe/Authenticator/LoginForm/RealMeLoginButton.ss
+++ b/templates/SilverStripe/RealMe/Authenticator/LoginForm/RealMeLoginButton.ss
@@ -1,4 +1,4 @@
 <span class="realme_button_padding">
     $Label
-    <span class="realme_icon_new_window"></span> <span class="realme_icon_padlock"></span>
+    <% if ShowNewWindowIcon %><span class="realme_icon_new_window"></span><% end_if %> <span class="realme_icon_padlock"></span>
 </span>


### PR DESCRIPTION
- Modified the RealMe login button template to align with the RealMe Login and assert button style guide.
- Added a 'ShowNewWindowIcon' boolean to the LoginForm form action. Depending on the value show the RealMe new window icon in the RealMe login button template. 