### PR TITLE
WIP NEW Add support for the address verification service

### DIFF
--- a/src/Model/FederatedAddress.php
+++ b/src/Model/FederatedAddress.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace SilverStripe\RealMe\Model;
+
+use DOMDocument;
+use DOMXPath;
+use SilverStripe\View\ViewableData;
+
+/**
+ * Class FederatedAddress
+ *
+ * Contains data to describe the address returned as part of an identity.
+ *
+ * @see https://developers.realme.govt.nz/how-realme-works/verified-address-data/
+ */
+class FederatedAddress extends ViewableData
+{
+    /**
+     * Types of addresses
+     */
+    const TYPE_STANDARD = 'NZStandard';
+    const TYPE_RURAL_DELIVERY = 'NZRuralDelivery';
+
+    /**
+     * @var string The type of address, either NZStandard or NZRuralDelivery
+     */
+    public $AddressType;
+
+    /**
+     * @var string Date when this address was marked as verified
+     */
+    public $VerificationDate;
+
+    /**
+     * @var string Undocumented in RealMe messaging spec, generally describes the quality of the address information
+     */
+    public $DataQuality;
+
+    /**
+     * @var string Street number, suffix, and the name of the street, e.g 103 Courtenay Place
+     */
+    public $NZNumberStreet;
+
+    /**
+     * @var string String representing the RD number of this address, e.g RD 123. Required if the address type is rural
+     */
+    public $NZRuralDelivery;
+
+    /**
+     * @var string Optional name of the suburb for this city, e.g Te Aro
+     */
+    public $NZSuburb;
+
+    /**
+     * @var string Name of the town or city for this address, e.g Wellington
+     */
+    public $NZTownOrCity;
+
+    /**
+     * @var string Alphanumeric 4 digit string representing a postcode with leading zeroes, e.g 6011 or 0002
+     */
+    public $NZPostCode;
+
+    /**
+     * Constructor that sets the expected federated identity details based on a provided DOMDocument. The expected XML
+     * structure for the DOMDocument is the following:
+     *
+     * <?xml version="1.0" encoding="UTF-8"?>
+     * <p:Party
+     *  xmlns:p="urn:oasis:names:tc:ciq:xpil:3"
+     *  xmlns:a="urn:oasis:names:tc:ciq:xal:3">
+     *     <a:Addresses>
+     *          <a:Address Type="NZStandard" Usage="Residential" DataQualityType="Valid" ValidFrom="13/11/2012">
+     *              <a:Locality>
+     *                  <a:NameElement a:NameType="NZTownCity">Wellington</a:NameElement>
+     *                  <a:NameElement a:NameType="NZSuburb">Kelburn</a:NameElement>
+     *              </a:Locality>
+     *              <a:Thoroughfare>
+     *                  <a:NameElement a:NameType="NZNumberStreet">1 Main St</a:NameElement>
+     *              </a:Thoroughfare>
+     *              <a:PostCode>
+     *                  <a:Identifier Type="NZPostCode">1111</a:Identifier>
+     *              </a:PostCode>
+     *         </a:Address>
+     *     </a:Addresses>
+     * </p:Party>
+     *
+     * @param DOMDocument $identity
+     */
+    public function __construct(DOMDocument $identity)
+    {
+        parent::__construct();
+
+        $xpath = new DOMXPath($identity);
+        $xpath->registerNamespace('p', 'urn:oasis:names:tc:ciq:xpil:3');
+        $xpath->registerNamespace('a', 'urn:oasis:names:tc:ciq:xal:3');
+
+        // Record info
+        $this->DataQuality = $this->getNamedItemNodeValue($xpath, '/p:Party/a:Addresses/a:Address', 'DataQualityType');
+        $this->VerificationDate = $this->getNamedItemNodeValue($xpath, '/p:Party/a:Addresses/a:Address', 'ValidFrom');
+
+        // Address info
+        $this->AddressType = $this->getNamedItemNodeValue($xpath, '/p:Party/a:Addresses/a:Address', 'Type');
+        $this->NZNumberStreet = $this->getNodeValue(
+            $xpath,
+            "/p:Party/a:Addresses/a:Address/a:Thoroughfare/a:NameElement[@a:NameType='NZNumberStreet']"
+        );
+        $this->NZRuralDelivery = $this->getNodeValue(
+            $xpath,
+            "/p:Party/a:Addresses/a:Address/a:RuralDelivery/a:Identifier[@Type='NZRuralDelivery']"
+        );
+        $this->NZSuburb = $this->getNodeValue(
+            $xpath,
+            "/p:Party/a:Addresses/a:Address/a:Locality/a:NameElement[@a:NameType='NZSuburb']"
+        );
+        $this->NZTownOrCity = $this->getNodeValue(
+            $xpath,
+            "/p:Party/a:Addresses/a:Address/a:Locality/a:NameElement[@a:NameType='NZTownCity']"
+        );
+        $this->NZPostCode = $this->getNodeValue(
+            $xpath,
+            "/p:Party/a:Addresses/a:Address/a:PostCode/a:Identifier[@Type='NZPostCode']"
+        );
+    }
+
+    /**
+     * @return bool
+     */
+    public function isRuralDeliveryAddress()
+    {
+        return $this->AddressType === self::TYPE_RURAL_DELIVERY;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isValid()
+    {
+        return true;
+    }
+
+    /**
+     * @param DOMXPath $xpath The DOMXPath object to carry out the query on
+     * @param string $query The XPath query to find the relevant node
+     * @param string $namedAttr The named attribute to retrieve from the XPath query
+     * @return string|null Either the value from the named item, or null if no item exists
+     */
+    private function getNamedItemNodeValue(DOMXPath $xpath, $query, $namedAttr)
+    {
+        $query = $xpath->query($query);
+        $value = null;
+
+        if ($query->length > 0) {
+            $item = $query->item(0);
+
+            if ($item->hasAttributes()) {
+                $value = $item->attributes->getNamedItem($namedAttr);
+
+                if (strlen($value->nodeValue) > 0) {
+                    $value = $value->nodeValue;
+                }
+            }
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param DOMXPath $xpath The DOMXPath object to carry out the query on
+     * @param string $query The XPath query to find the relevant node
+     * @return string|null Either the first matching node's value (there should only ever be one), or null if none found
+     */
+    private function getNodeValue(DOMXPath $xpath, $query)
+    {
+        $query = $xpath->query($query);
+        return ($query->length > 0 ? $query->item(0)->nodeValue : null);
+    }
+}

--- a/src/Model/FederatedAddress.php
+++ b/src/Model/FederatedAddress.php
@@ -42,6 +42,11 @@ class FederatedAddress extends ViewableData
     public $NZNumberStreet;
 
     /**
+     * @var string Unit number for the address
+     */
+    public $NZUnit;
+
+    /**
      * @var string String representing the RD number of this address, e.g RD 123. Required if the address type is rural
      */
     public $NZRuralDelivery;
@@ -78,6 +83,9 @@ class FederatedAddress extends ViewableData
      *              <a:Thoroughfare>
      *                  <a:NameElement a:NameType="NZNumberStreet">1 Main St</a:NameElement>
      *              </a:Thoroughfare>
+     *              <a:Premises>
+     *                  <a:NameElement a:NameType="NZUnit">14</a:NameElement>
+     *              </a:Premises>
      *              <a:PostCode>
      *                  <a:Identifier Type="NZPostCode">1111</a:Identifier>
      *              </a:PostCode>
@@ -104,6 +112,10 @@ class FederatedAddress extends ViewableData
         $this->NZNumberStreet = $this->getNodeValue(
             $xpath,
             "/p:Party/a:Addresses/a:Address/a:Thoroughfare/a:NameElement[@a:NameType='NZNumberStreet']"
+        );
+        $this->NZUnit = $this->getNodeValue(
+            $xpath,
+            "/p:Party/a:Addresses/a:Address/a:Premises/a:NameElement[@a:NameType='NZUnit']"
         );
         $this->NZRuralDelivery = $this->getNodeValue(
             $xpath,

--- a/src/Model/FederatedIdentity.php
+++ b/src/Model/FederatedIdentity.php
@@ -99,6 +99,11 @@ class FederatedIdentity extends ViewableData
     public $BirthPlaceLocality;
 
     /**
+     * @var null|FederatedAddress The verified address for this user as returned by the AVS
+     */
+    public $Address;
+
+    /**
      * Constructor that sets the expected federated identity details based on a provided DOMDocument. The expected XML
      * structure for the DOMDocument is the following:
      *


### PR DESCRIPTION
The PR adds support for the address verification service, which returns data as part of a RealMe assertion. 

```
object(SilverStripe\RealMe\Model\FederatedIdentity)[691]
  private 'nameId' => string '4196b8a8a68d4e7a8ef18df532a6dfaf' (length=32)
  public 'FirstName' => string 'Edmund' (length=6)
  public 'MiddleName' => string 'Percival' (length=8)
  public 'LastName' => string 'Hillary' (length=7)
  public 'Gender' => string 'M' (length=1)
  public 'BirthInfoQuality' => 
    object(DOMNodeList)[709]
      public 'length' => int 0
  public 'BirthYear' => string '1919' (length=4)
  public 'BirthMonth' => string '07' (length=2)
  public 'BirthDay' => string '20' (length=2)
  public 'BirthPlaceQuality' => string 'Valid' (length=5)
  public 'BirthPlaceCountry' => string 'New Zealand' (length=11)
  public 'BirthPlaceLocality' => string 'Auckland' (length=8)
  public 'Address' => 
    object(SilverStripe\RealMe\Model\FederatedAddress)[710]
      public 'AddressType' => string 'NZStandard' (length=10)
      public 'VerificationDate' => string '13/11/2012' (length=10)
      public 'DataQuality' => string 'Valid' (length=5)
      public 'NZNumberStreet' => string '1 Main St' (length=9)
      public 'NZRuralDelivery' => null
      public 'NZSuburb' => string 'Kelburn' (length=7)
      public 'NZTownOrCity' => string 'Wellington' (length=10)
      public 'NZPostCode' => string '1111' (length=4)
```
One thing that may need to be verified by RealMe is if this service can return multiple addresses, as the slightly-basic page on their website doesn't specify: https://developers.realme.govt.nz/how-realme-works/verified-address-data/

Comments welcome!