### PR TITLE
Minor - fix for character encodings on private key

### DIFF
--- a/src/RealMeService.php
+++ b/src/RealMeService.php
@@ -730,7 +730,8 @@ class RealMeService implements TemplateGlobalProvider
                 if ($contentType == 'certificate') {
                     $pattern = '/-----BEGIN CERTIFICATE-----[\r\n]*([^-]*)[\r\n]*-----END CERTIFICATE-----/';
                 } elseif ($contentType == 'key') {
-                    $pattern = '/-----BEGIN [A-Z ]*PRIVATE KEY-----[\r\n]*([^-]*)[\r\n]*-----END [A-Z ]*PRIVATE KEY-----/';
+                    $pattern = '/-----BEGIN [A-Z ]*PRIVATE KEY-----[\r\n]*([^-]*)[\r\n]*'
+                        . '-----END [A-Z ]*PRIVATE KEY-----/';
                 } else {
                     throw new InvalidArgumentException('Argument contentType must be either "certificate" or "key"');
                 }

--- a/src/RealMeService.php
+++ b/src/RealMeService.php
@@ -730,7 +730,7 @@ class RealMeService implements TemplateGlobalProvider
                 if ($contentType == 'certificate') {
                     $pattern = '/-----BEGIN CERTIFICATE-----[\r\n]*([^-]*)[\r\n]*-----END CERTIFICATE-----/';
                 } elseif ($contentType == 'key') {
-                    $pattern = '/-----BEGIN [A-Z ]*PRIVATE KEY-----\n([^-]*)\n-----END [A-Z ]*PRIVATE KEY-----/';
+                    $pattern = '/-----BEGIN [A-Z ]*PRIVATE KEY-----[\r\n]*([^-]*)[\r\n]*-----END [A-Z ]*PRIVATE KEY-----/';
                 } else {
                     throw new InvalidArgumentException('Argument contentType must be either "certificate" or "key"');
                 }


### PR DESCRIPTION
Allow for windows character encoding for the private key section in pem files. This will make it consistent for public keys, and reduces the risk third party apps will re-encode the key by mistake. 