### PR TITLE
Pulls/3.1/un mcrypt my heart

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,8 @@
         }
     ],
     "require": {
-        "php": "<7.2.0",
-        "silverstripe/framework": "^4.0",
-        "onelogin/php-saml": "~2.10"
+        "silverstripe/framework": "^4",
+        "onelogin/php-saml": "^3"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/tests/RealMeServiceTest.php
+++ b/tests/RealMeServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\RealMe\Tests;
 
+use OneLogin\Saml2\Auth;
 use SilverStripe\Control\NullHTTPRequest;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Environment;
@@ -66,7 +67,7 @@ class RealMeServiceTest extends SapphireTest
     public function testGetAuth()
     {
         $auth = $this->service->getAuth(new NullHTTPRequest());
-        $this->assertTrue(get_class($auth) === 'OneLogin_Saml2_Auth');
+        $this->assertTrue(get_class($auth) === Auth::class);
 
         // Service Provider settings
         $spData = $auth->getSettings()->getSPData();


### PR DESCRIPTION
Update dependencies (and references to classes used thereof) to be PHP 7.2+ compatible, via removing the reliance to the mcrypt library that has been removed from PHP.

resolves https://github.com/silverstripe/silverstripe-realme/issues/24