### PR TITLE
FIX log in after logging in

### DIFF
--- a/src/Authenticator/LoginHandler.php
+++ b/src/Authenticator/LoginHandler.php
@@ -13,7 +13,7 @@ use SilverStripe\RealMe\Exception as RealMeException;
 use SilverStripe\RealMe\Extension\MemberExtension;
 use SilverStripe\RealMe\RealMeService;
 use SilverStripe\Security\Member;
-use SilverStripe\Security\RequestAuthenticationHandler;
+use SilverStripe\Security\AuthenticationHandler;
 use SilverStripe\Security\Security;
 
 class LoginHandler extends RequestHandler
@@ -115,7 +115,7 @@ class LoginHandler extends RequestHandler
                         $authData->getMember()->write();
                     }
                     if (RealMeService::config()->get('login_member_after_authentication') === true) {
-                        Injector::inst()->get(RequestAuthenticationHandler::class)->login($authData->getMember());
+                        Injector::inst()->get(AuthenticationHandler::class)->login($authData->getMember());
                     }
                 }
 


### PR DESCRIPTION
When the config options for syncing members and logging a member in after authentication with RealMe are enabled, we should log a user in when they authenticate with RealMe. This was broken because a new RequestAuthenticationHandler contains no assigned member handlers, and thus the login() call was essentially a no-op. Using the named service AuthenticationHandler however (as defined in silverstripe/framework) has handlers assigned, and thus actually logs a member in after it has been matched to the RealMe FLT (or FIT) data.

Resolves #46 