### PR TITLE
make css more specific as to avoid interference

### DIFF
--- a/client/css/realme.css
+++ b/client/css/realme.css
@@ -20,6 +20,13 @@
   position: absolute;
 }
 
+.realme_login_lockup form img {
+  border: 0;
+  margin: 0;
+  padding: 0;
+  background: transparent;
+}
+
 /* Clearfix */
 .realme_widget, .realme_secondary_login, .realme_login_lockup, .realme_popup {
   /**
@@ -94,27 +101,32 @@
 .realme_widget p {
   margin-top: 0.5em;
   margin-bottom: 1em;
+  font-family: sans-serif;
 }
 .realme_widget a {
   text-decoration: none;
+  font-family: sans-serif;
 }
 
-.realme_login, .realme_create_account, .whats_realme, .realme_link {
+.realme_widget .realme_login, .realme_widget .realme_create_account, .realme_widget .whats_realme, .realme_widget .realme_link {
   color: #2c5897;
 }
-.realme_login:hover, .realme_create_account:hover, .whats_realme:hover, .realme_link:hover, .realme_login:active, .realme_create_account:active, .whats_realme:active, .realme_link:active {
+.realme_widget .realme_login:hover, .realme_widget .realme_create_account:hover, .realme_widget .whats_realme:hover, .realme_widget .realme_link:hover, .realme_widget .realme_login:active, .realme_widget .realme_create_account:active, .realme_widget .whats_realme:active, .realme_widget .realme_link:active {
   color: #204170;
   text-decoration: underline;
+  border: 0;
 }
 
 /*
 	Typography
 	-----------------------------------------------------
 */
-.realme_title {
+.realme_widget .realme_title {
   margin-top: 0;
   margin-bottom: 0;
   font-size: 1.230769231em;
+  font-family: sans-serif;
+  font-weight: bold;
   /* 16px */
 }
 
@@ -158,6 +170,7 @@
    */
   width: 100%;
   text-align: left;
+  padding: 0;
 }
 .realme_button:hover, .realme_button:focus {
   background-color: #2f5f93;
@@ -252,6 +265,10 @@
   margin-bottom: 1em;
   _position: relative;
   /*ie6*/
+}
+
+.realme_login_lockup form {
+  width: 100%;
 }
 
 /*
@@ -590,7 +607,9 @@
 .realme_theme_dark .realme_hr, .realme_theme_dark .realme_pipe {
   border-color: #587a90;
 }
-.realme_theme_dark .realme_login, .realme_theme_dark .realme_create_account, .realme_theme_dark .whats_realme, .realme_theme_dark .realme_link {
+.realme_theme_dark .realme_login, .realme_theme_dark .realme_create_account, .realme_theme_dark .whats_realme, .realme_theme_dark .realme_link,
+.realme_theme_dark .realme_login:hover, .realme_theme_dark .realme_create_account:hover, .realme_theme_dark .whats_realme:hover, .realme_theme_dark .realme_link:hover,
+.realme_theme_dark .realme_login:active, .realme_theme_dark .realme_create_account:active, .realme_theme_dark .whats_realme:active, .realme_theme_dark .realme_link:active {
   color: #fff;
 }
 .realme_theme_dark .realme_icon_link {


### PR DESCRIPTION
The RealMe login detail box is strongly specified by the RealMe design team. It needs to look one of three pre-defiend ways, without modifications caused by cascading rules.
However the CSS supplied is not specific enough (nor perscriptive enough with the rules) to ensure that this is the case. So we can tighten this to be more robust.