### PR TITLE
Check for current controller

### DIFF
--- a/src/RealMeService.php
+++ b/src/RealMeService.php
@@ -433,7 +433,7 @@ class RealMeService implements TemplateGlobalProvider
 
         // If not, attempt to retrieve authentication data from OneLogin (in case this is called during SAML assertion)
         try {
-            if (!$session->get("RealMeErrorBackURL")) {
+            if (!$session->get("RealMeErrorBackURL") && Controller::has_curr()) {
                 $session->set("RealMeErrorBackURL", Controller::curr()->Link("Login"));
             }
 


### PR DESCRIPTION
The `RealMeService::enforceLogin` method should check a controller exists before using `Controller::curr()->Link("Login")` otherwise `Link` can be called on `null` resulting in an error.

It's a bit of an edge case but can happen when using BasicAuth. BasicAuth gets a list of authenticators then tries them in order until a valid `Member` is returned or there's no more authenticators to try.

If a user enters bad credentials into BasicAuth, the RealMe authenticator will get called, and in turn call `RealMeService::enforceLogin`. At this point there is no current controller, so you get an error.

