### PR TITLE
Fix: New RealMe MTS entity IDs and SSOService endpoints

### DIFF
--- a/src/RealMeService.php
+++ b/src/RealMeService.php
@@ -135,9 +135,9 @@ class RealMeService implements TemplateGlobalProvider
      */
     private static $idp_entity_ids = array(
         self::ENV_MTS => array(
-            self::TYPE_LOGIN  => 'https://mts.login.realme.govt.nz/4af8e0e0-497b-4f52-805c-00fa09b50c16' .
+            self::TYPE_LOGIN  => 'https://login.mts.realme.govt.nz/4af8e0e0-497b-4f52-805c-00fa09b50c16' .
                 '/B2C_1A_DIA_RealMe_MTSLoginService',
-            self::TYPE_ASSERT => 'https://mts.login.realme.govt.nz/4af8e0e0-497b-4f52-805c-00fa09b50c16' .
+            self::TYPE_ASSERT => 'https://login.mts.realme.govt.nz/4af8e0e0-497b-4f52-805c-00fa09b50c16' .
                 '/B2C_1A_DIA_RealMe_MTSAssertionService'
         ),
 
@@ -158,9 +158,9 @@ class RealMeService implements TemplateGlobalProvider
 
     private static $idp_sso_service_urls = array(
         self::ENV_MTS => array(
-            self::TYPE_LOGIN  => 'https://mts.login.realme.govt.nz/4af8e0e0-497b-4f52-805c-00fa09b50c16' .
+            self::TYPE_LOGIN  => 'https://login.mts.realme.govt.nz/b2cdiamts01rmpubdir.onmicrosoft.com' .
                 '/B2C_1A_DIA_RealMe_MTSLoginService/samlp/sso/login',
-            self::TYPE_ASSERT => 'https://mts.login.realme.govt.nz/4af8e0e0-497b-4f52-805c-00fa09b50c16' .
+            self::TYPE_ASSERT => 'https://login.mts.realme.govt.nz/b2cdiamts01rmpubdir.onmicrosoft.com' .
                 '/B2C_1A_DIA_RealMe_MTSAssertionService/samlp/sso/login'
         ),
 

--- a/tests/RealMeServiceTest.php
+++ b/tests/RealMeServiceTest.php
@@ -77,12 +77,12 @@ class RealMeServiceTest extends SapphireTest
 
         // Identity Provider settings
         $idpData = $auth->getSettings()->getIdPData();
-        $expected = 'https://mts.login.realme.govt.nz' .
+        $expected = 'https://login.mts.realme.govt.nz' .
             '/4af8e0e0-497b-4f52-805c-00fa09b50c16/B2C_1A_DIA_RealMe_MTSLoginService';
         $this->assertSame($expected, $idpData['entityId']);
 
-        $expected = 'https://mts.login.realme.govt.nz' .
-            '/4af8e0e0-497b-4f52-805c-00fa09b50c16/B2C_1A_DIA_RealMe_MTSLoginService/samlp/sso/login';
+        $expected = 'https://login.mts.realme.govt.nz' .
+            '/b2cdiamts01rmpubdir.onmicrosoft.com/B2C_1A_DIA_RealMe_MTSLoginService/samlp/sso/login';
         $this->assertSame($expected, $idpData['singleSignOnService']['url']);
 
         // Security settings


### PR DESCRIPTION
During the October 2021 certificate renewal process, RealMe have *also* changed the entity ID and SingleSignOnService endpoint URLs.