### PR TITLE
Fix typo in var name

### DIFF
--- a/src/RealMeService.php
+++ b/src/RealMeService.php
@@ -453,12 +453,8 @@ class RealMeService implements TemplateGlobalProvider
             $backUrl = $this->getBackURL($request);
         }
 
-        $backURL = $this->validSiteURL($backURL);
-        
-        if (!$backUrl) {
-            $backURL = Director::absoluteBaseURL();
-        }
-        
+        $backUrl = $this->validSiteURL($backUrl);
+
         // If not, attempt to retrieve authentication data from OneLogin (in case this is called during SAML assertion)
         try {
             if (!$session->get("RealMeErrorBackURL") && Controller::has_curr()) {
@@ -488,7 +484,7 @@ class RealMeService implements TemplateGlobalProvider
             Member::singleton()->extend("onRealMeLoginFailure", $e);
 
             // No auth data or failed to decrypt, enforce login again
-            $this->getAuth()->login($backURL);
+            $this->getAuth()->login($backUrl);
             die;
         }
 


### PR DESCRIPTION
Hey guys,

<tl/dr>Please consider my fix for a typo in a var name</tl/dr>

I ended up fixing up my patch for the backURL through the github web editor, because my projects local linter settings were incompatible with the modules. That is how I didn't pick up on a typo in the var name $backU**RL**.

Sorry about that.

No need to hurry as I cannot use the fix, because with the new realme branch 4.2 came a bump of the PHP version and upgrading our project is not in scope.

Cheers

Andy