### PR TITLE
FIX: Quote yml string

### DIFF
--- a/_config/auth.yml
+++ b/_config/auth.yml
@@ -7,4 +7,4 @@ SilverStripe\Core\Injector\Injector:
   SilverStripe\Security\Security:
     properties:
       Authenticators:
-        RealMe: %$SilverStripe\RealMe\Authenticator
+        RealMe: '%$SilverStripe\RealMe\Authenticator'


### PR DESCRIPTION
This is blocking upgrades to the most recent recipes. It already exists on more up-to-date branches, but its not always possible to update this module on any given project: https://github.com/silverstripe/silverstripe-realme/commit/7f2c31a0b8ee2891eb59a0c1025b6cb6eda99509