### PR TITLE
FIX: Quote yml string

### DIFF
--- a/_config/auth.yml
+++ b/_config/auth.yml
@@ -7,4 +7,4 @@ SilverStripe\Core\Injector\Injector:
   SilverStripe\Security\Security:
     properties:
       Authenticators:
-        RealMe: %$SilverStripe\RealMe\Authenticator
+        RealMe: '%$SilverStripe\RealMe\Authenticator'


### PR DESCRIPTION
This is blocking upgrades to the most recent recipes. It already exists on more up-to-date branches: https://github.com/silverstripe/silverstripe-realme/commit/7f2c31a0b8ee2891eb59a0c1025b6cb6eda99509

This is the same PR as https://github.com/silverstripe/silverstripe-realme/pull/84, though based from and targetting 3.1 so that we can do a patch release

Unit tests are expected to fail due to out of date travis config

That PR was already approved, this is just a cherry-pick PR so self-merging.

[Tagged 3.1.5](https://github.com/silverstripe/silverstripe-realme/releases/tag/3.1.5)
