### PR TITLE
Fixing "Undefined variable $backURL" in enforeLogin function

### DIFF
--- a/src/RealMeService.php
+++ b/src/RealMeService.php
@@ -453,7 +453,7 @@ class RealMeService implements TemplateGlobalProvider
             $backUrl = $this->getBackURL($request);
         }
 
-        $backURL = $this->validSiteURL($backURL);
+        $backURL = $this->validSiteURL($backUrl);
         
         if (!$backUrl) {
             $backURL = Director::absoluteBaseURL();

--- a/src/RealMeService.php
+++ b/src/RealMeService.php
@@ -453,10 +453,10 @@ class RealMeService implements TemplateGlobalProvider
             $backUrl = $this->getBackURL($request);
         }
 
-        $backURL = $this->validSiteURL($backUrl);
+        $backUrl = $this->validSiteURL($backUrl);
         
         if (!$backUrl) {
-            $backURL = Director::absoluteBaseURL();
+            $backUrl = Director::absoluteBaseURL();
         }
         
         // If not, attempt to retrieve authentication data from OneLogin (in case this is called during SAML assertion)
@@ -488,7 +488,7 @@ class RealMeService implements TemplateGlobalProvider
             Member::singleton()->extend("onRealMeLoginFailure", $e);
 
             // No auth data or failed to decrypt, enforce login again
-            $this->getAuth()->login($backURL);
+            $this->getAuth()->login($backUrl);
             die;
         }
 


### PR DESCRIPTION
Note, there is already a pull request for this issue which looks to be abandoned:
https://github.com/silverstripe/silverstripe-realme/pull/81

This pull request is a simpler fix which doesn't remove the call to validSiteURL.  

Unfortunately, I also do not have time to contribute a unit test to the repository.

