### PR TITLE
FIX Change "login" to "log in" when used as a verb

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -3,6 +3,7 @@ en:
     ASSERTLOGINBUTTON: 'Share your details with {orgname}'
     AUTHENTICATOR_NAME: 'RealMe Account'
     LOGINBUTTON: Login
+    LOGINBUTTON2: Log in
   SilverStripe\RealMe\Authenticator\LoginHandler:
     LOGINFAILURE: 'Unfortunately we''re not able to log you in through RealMe right now. Please try again shortly.'
   SilverStripe\RealMe\Authenticator\MiniLoginForm:

--- a/src/Authenticator/LoginForm.php
+++ b/src/Authenticator/LoginForm.php
@@ -202,13 +202,13 @@ class LoginForm extends BaseLoginForm
         } else {
             // Login button
             $loginButtonContent = ArrayData::create(array(
-                'Label' => _t(self::class . '.LOGINBUTTON', 'Login'),
+                'Label' => _t(self::class . '.LOGINBUTTON2', 'Log in'),
                 'ShowNewWindowIcon' => true
             ))->renderWith(self::class . '/RealMeLoginButton');
         }
 
         return FieldList::create(array(
-            FormAction::create('doLogin', _t(self::class . '.LOGINBUTTON', 'Login'))
+            FormAction::create('doLogin', _t(self::class . '.LOGINBUTTON2', 'Log in'))
                 ->setUseButtonTag(true)
                 ->setButtonContent($loginButtonContent)
                 ->setAttribute('class', 'realme_button')

--- a/templates/SilverStripe/RealMe/Authenticator/LoginForm.ss
+++ b/templates/SilverStripe/RealMe/Authenticator/LoginForm.ss
@@ -39,11 +39,11 @@ or directly in your css, e.g. .realme_popup {width: 450px}
 <% end_if %>
 
 <div class="realme_widget realme_primary_login realme_theme_{$RealMeWidgetTheme}">
-    <h2 class="realme_title">Login with <span class="realme_title_brand">RealMe</span></h2>
+    <h2 class="realme_title">Log in with <span class="realme_title_brand">RealMe</span></h2>
 
     <p class="realme_info">
         To access the $ServiceName1, you need a RealMe login. If you've used a RealMe login somewhere else, you can use
-        it here too. If you don't already have a username and password, just select Login and choose to create one.
+        it here too. If you don't already have a username and password, just select "Log in" and choose to create one.
     </p>
 
     <div class="realme_login_lockup">

--- a/templates/SilverStripe/RealMe/Authenticator/LoginForm_secondary.ss
+++ b/templates/SilverStripe/RealMe/Authenticator/LoginForm_secondary.ss
@@ -40,14 +40,14 @@ or directly in your css, e.g. .realme_popup {width: 450px}
 
 "--%>
 <div class="realme_widget realme_secondary_login realme_theme_dark no_touch" style="z-index: 1;">
-    <a href="{$BaseHref}Security/login#RealMeLoginForm_LoginForm" class="realme_login realme_pipe">Login <span class="realme_icon_link"></span></a>
+    <a href="{$BaseHref}Security/login#RealMeLoginForm_LoginForm" class="realme_login realme_pipe">Log in <span class="realme_icon_link"></span></a>
     <a href="https://www.account.realme.govt.nz/account/" class="realme_create_account realme_pipe">Create <span class="realme_icon_link"></span></a>
     <div class="realme_popup_position">
         <a id="popup_trigger" href="http://www.realme.govt.nz" target="_blank" class="realme_link whats_realme">?</a>
         <div class="realme_popup_wrapper realme_arrow_top_left">
             <!-- realme_popup -->
             <div class="realme_popup">
-                <h2 class="realme_popup_title">To login to this service you now need a RealMe account.</h2>
+                <h2 class="realme_popup_title">To log in to this service you now need a RealMe account.</h2>
                 <p><b>RealMe</b> is a service from the New Zealand government and New Zealand Post that includes a single login, letting you use one username and password to access a wide range of services online.</p>
                 <p>But there is much more to <b>RealMe</b> than just the convenience of a single login.</p>
                 <h2 class="realme_popup_title">Get Verified</h2>

--- a/templates/SilverStripe/RealMe/Authenticator/MiniLoginForm.ss
+++ b/templates/SilverStripe/RealMe/Authenticator/MiniLoginForm.ss
@@ -1,5 +1,5 @@
 <div class='realme_widget realme_secondary_login realme_theme_light'>
-    <a href='$RealMeMiniLoginLink' class='realme_login realme_pipe'>Login <span class='realme_icon_link'></span></a>
+    <a href='$RealMeMiniLoginLink' class='realme_login realme_pipe'>Log in <span class='realme_icon_link'></span></a>
     <div class='realme_popup_position'>
         <a id='popup_trigger' href='http://www.realme.govt.nz' target='_blank' class='link realme_link whats_realme'>?</a>
 


### PR DESCRIPTION
Note that I have intentionally not changed it when it's used as a noun, which seems to be consistent with the way realme themselves use "login".

## Issue
- https://github.com/silverstripe/silverstripe-realme/issues/121