### PR TITLE
DOC Update link

### DIFF
--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -4,7 +4,7 @@
 
 ### Environment variables and certificates
 
-The following values need to be defined in your `.env` file for **all** environments. See the [SilverStripe documentation on environment management](https://docs.silverstripe.org/en/3.1/getting_started/environment_management/) for more information.
+The following values need to be defined in your `.env` file for **all** environments. See the [SilverStripe documentation on environment management](https://docs.silverstripe.org/en/getting_started/environment_management/) for more information.
 
 | **Environment Const**          | **Example**                     | **Notes**                                                                                                                                                                                    |
 | ------------------------------ | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-realme/issues/181

I've checked all the other links in the realme docs to docs.silverstripe.org, there was only one that pointed to a specific version of Silverstripe.

I checked all the others links in the realme docs and they all go where they are supposed to i.e. no dead links